### PR TITLE
Modifying architecture: consume explicit PHENOMAP_SPECS (v1 format)

### DIFF
--- a/docs/phenotype-lo-hi-double-rescale.md
+++ b/docs/phenotype-lo-hi-double-rescale.md
@@ -1,0 +1,81 @@
+# Known issue: the lo/hi range is applied twice in the phenotype pipeline
+
+**Status:** known, deliberately not fixed (2026-07-16). Read this before changing
+`Phenotypes.clip_array_to_01`, `G_<trait>_lo` / `G_<trait>_hi`, or the default
+survival/reproduction parameters.
+
+Found while reproducing the v1 Ne / MA / AP paper under v2. Two separate problems were
+compounding; one is fixed, one is documented here because the "obvious" fix is unsafe.
+
+## The bug
+
+`Phenotypes.clip_array_to_01` runs in the `Phenotypes` constructor and, despite its name,
+*rescales* rather than clips:
+
+```python
+new_values = lo + values * (hi - lo)
+```
+
+But the architectures already own the lo/hi mapping:
+
+- **composite** applies it itself in `compute()` (`composite/architecture.py`), and
+- **modifying** doesn't use lo/hi at all — `initpheno` is the baseline in real units.
+
+So the range gets applied a second time on top. Consequences:
+
+- **Composite:** an all-zero genome yields surv **0.91**, not the documented floor of
+  **0.70**. (`G_surv_lo`'s own docstring promises "a 50%-genome individual has surv ~0.85";
+  the code actually produces ~0.955.) Every composite run is sitting on an inflated
+  survival baseline.
+- **Modifying:** `zeropheno` (nominally "the phenotype of an all-zero genome") is rescaled
+  to `lo` (0.70) *before* `compute()` adds `initpheno` (0.95) → 1.65 → clipped to 1.0.
+  With `G_surv_lo=0.7` there is **no headroom**, so the phenomap — AP or MA — can never
+  move survival off 1.0. Survival appears permanently flat at 1.0.
+
+## Why it is not fixed
+
+Making it a true clip is correct per the documentation, but **the default parameter regime
+is implicitly calibrated to the inflated survival**. With the fix, a 50%-genome individual
+drops from surv ~0.955 to the documented ~0.85, and the *default* composite population
+goes **extinct by ~step 30** (reproducible: `tests/functional/test_zcontainer.py` passes
+31/31 on `v2`, and fails with the fix as the population dies out).
+
+A correct fix therefore is not a one-liner. It requires:
+
+1. changing `clip_array_to_01` to actually clip to [0, 1];
+2. re-tuning the default surv / repr / reproduction parameters so populations stay viable;
+3. accepting that all historical composite results shift, and saying so in the changelog.
+
+That is a research decision with no deadline, so it has been left alone deliberately
+rather than fixed by halves.
+
+## If you hit this
+
+Under the **modifying** architecture, lo/hi are not the range mechanism. Set them out of
+the way and drive the trait from `initpheno`:
+
+```yaml
+G_surv_lo: 0.0
+G_surv_hi: 1.0
+G_surv_initpheno: 0.85     # survival baseline
+G_repr_lo: 0.0
+G_repr_hi: 1.0
+G_repr_initpheno: 0.15     # reproduction baseline
+G_neut_initgeno: 0.5       # start from a distribution around mid, not all-off
+```
+
+Note that `G_repr_hi` no longer acts as a hard ceiling on the reproduction rate this way;
+keep the baseline low and phenomap magnitudes small to stay in range.
+
+Also: with `G_neut_initgeno: 0` the driver loci start empty, so age-structure only emerges
+over the full run — short smoke tests look flat even when everything is wired correctly.
+`initgeno: 0.5` starts traits as a per-individual distribution around the midpoint, so the
+signal is visible immediately and selection can push traits up *or* down.
+
+## Related fix (shipped)
+
+`PHENOMAP_SPECS` — the explicit `[source, site, trait, age, magnitude]` phenolist that v1
+exports, used by the Ne/MA/AP paper configs — was **never read anywhere in the engine**.
+Only the `PHENOMAP` dict shorthand was, which *stochastically generates* a map. Any config
+carrying an explicit map therefore ran with an empty phenomap and zero pleiotropy, silently.
+`ModifyingArchitecture` now consumes `PHENOMAP_SPECS` when non-empty.

--- a/src/aegis_sim/submodels/genetics/modifying/architecture.py
+++ b/src/aegis_sim/submodels/genetics/modifying/architecture.py
@@ -4,6 +4,7 @@ from aegis_sim import constants
 from aegis_sim import variables
 from aegis_sim import parameterization
 
+from aegis_sim.parameterization import parametermanager
 from aegis_sim.submodels.genetics.modifying.gpm_decoder import GPM_decoder
 from aegis_sim.submodels.genetics.modifying.gpm import GPM
 from aegis_sim.submodels.genetics import ploider
@@ -27,7 +28,19 @@ class ModifyingArchitecture:
 
         self.length = MODIF_GENOME_SIZE
 
-        phenolist = self.gpm_decoder.get_total_phenolist()
+        # Two ways to specify the genotype-phenotype map for the modifying architecture:
+        #   1. PHENOMAP (dict shorthand) -> gpm_decoder *stochastically generates* a phenolist
+        #      from block specs like {"AP, 88": [["surv", "agespec", 0.003]]}.
+        #   2. PHENOMAP_SPECS (explicit v1 phenolist) -> a flat list of
+        #      [source, site, trait, age, magnitude] quintuples that fully determine the map.
+        #      This is the format exported by aegis v1 (e.g. the Ne/MA/AP paper configs).
+        # If PHENOMAP_SPECS is provided, use it verbatim so exact v1 maps reproduce bit-for-bit;
+        # otherwise fall back to the dict-shorthand decoder.
+        PHENOMAP_SPECS = parametermanager.parameters.PHENOMAP_SPECS
+        if PHENOMAP_SPECS:
+            phenolist = self._phenolist_from_specs(PHENOMAP_SPECS, AGE_LIMIT, MODIF_GENOME_SIZE)
+        else:
+            phenolist = self.gpm_decoder.get_total_phenolist()
         self.phenomap = GPM(
             phenomatrix=None,
             phenolist=phenolist,
@@ -36,6 +49,33 @@ class ModifyingArchitecture:
         # self.n_phenotypic_values = AGE_LIMIT * constants.TRAIT_N
 
         self.AGE_LIMIT = AGE_LIMIT
+
+    @staticmethod
+    def _phenolist_from_specs(PHENOMAP_SPECS, AGE_LIMIT, MODIF_GENOME_SIZE):
+        """Convert the explicit v1 PHENOMAP_SPECS into a GPM phenolist.
+
+        Each spec is a quintuple ``[source, site, trait, age, magnitude]`` where
+        ``site`` (1..MODIF_GENOME_SIZE) and ``age`` (1..AGE_LIMIT) are 1-based, as
+        exported by aegis v1. The GPM phenolist wants 0-based 4-tuples
+        ``(vec_index, trait, age, magnitude)``, so site/age are shifted by -1.
+
+        This is theory-agnostic: AP maps (paired +early / -late effects on the same
+        site) and MA maps (single deleterious late-acting effects) are both just
+        collections of such quintuples and convert identically.
+        """
+        phenolist = []
+        for spec in PHENOMAP_SPECS:
+            _source, site, trait, age, magnitude = spec
+            vec_index = int(site) - 1
+            age0 = int(age) - 1
+            assert 0 <= vec_index < MODIF_GENOME_SIZE, (
+                f"PHENOMAP_SPECS site {site} out of range for MODIF_GENOME_SIZE={MODIF_GENOME_SIZE}"
+            )
+            assert 0 <= age0 < AGE_LIMIT, (
+                f"PHENOMAP_SPECS age {age} out of range for AGE_LIMIT={AGE_LIMIT}"
+            )
+            phenolist.append([vec_index, trait, age0, float(magnitude)])
+        return phenolist
 
     def get_number_of_bits(self):
         return self.length * ploider.ploider.y


### PR DESCRIPTION
**Parked deliberately — not for merge right now.** Opened so the work isn't lost.

## What this does

The `modifying` architecture built its genotype-phenotype map only from the `PHENOMAP`
dict shorthand (which *stochastically generates* a phenolist). The explicit
`PHENOMAP_SPECS` parameter — the flat `[source, site, trait, age, magnitude]` phenolist
that aegis v1 exported, and that the Ne/MA/AP paper configs use — was **defined but read
nowhere in `src/`** (confirmed by full-tree grep and git history). Any config carrying an
explicit map therefore ran with an **empty phenomap and zero pleiotropy**, silently.

This restores genuine v1 behaviour: v1's `Gstruc` passed `PHENOMAP_SPECS=params["PHENOMAP_SPECS"]`
straight into its `Phenomap`. With this shim plus `G_surv_lo: 0`, v2 computes the paper's
equation literally — `P = G·M + 0.95`.

Also included: `docs/phenotype-lo-hi-double-rescale.md`, documenting the double-counting bug
where `Phenotypes.clip_array_to_01` rescales rather than clips.

## Why it's parked

We've **superseded this path**. The current model (merged in #composite-phenomap) uses the
composite architecture with a direct encoding, which removes the MA ceiling
(`P = G·M + 0.95` with all-negative M means survival can only ever *fall* from 0.95 — no
positive selection is possible by construction). The findings reproduce on the new model, so
nothing depends on this branch.

Kept because it's the only thing that makes v1-format configs run faithfully on v2, which
matters if anyone ever needs a bit-exact replication of Bagic & Valenzano 2022.

## Safety

Additive and backward-compatible: inactive when `PHENOMAP_SPECS` is empty (the default).
Genetics + basic-sim tests pass (18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)